### PR TITLE
replace trim_right() with trim_end()

### DIFF
--- a/src/link.rs
+++ b/src/link.rs
@@ -139,14 +139,14 @@ fn parse_end(
                 end: trail_end_position,
                 ordinal: vec![],
                 start: state.scan_position,
-                target: state.wiki_text[target_start_position..target_end_position].trim_right(),
+                target: state.wiki_text[target_start_position..target_end_position].trim_end(),
             });
         }
         Some(crate::Namespace::File) => {
             state.nodes.push(crate::Node::Image {
                 end: trail_end_position,
                 start: state.scan_position,
-                target: state.wiki_text[target_start_position..target_end_position].trim_right(),
+                target: state.wiki_text[target_start_position..target_end_position].trim_end(),
                 text: vec![],
             });
         }
@@ -177,7 +177,7 @@ fn parse_end(
             state.nodes.push(crate::Node::Link {
                 end: trail_end_position,
                 start: state.scan_position,
-                target: &state.wiki_text[target_start_position..target_end_position].trim_right(),
+                target: &state.wiki_text[target_start_position..target_end_position].trim_end(),
                 text,
             });
         }


### PR DESCRIPTION
Hi! I noticed `trim_right()` is now deprecated and superseded by `trim_end()`. 