### PR TITLE
Convenience method for getting node text from Node and slice of Node

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -79,7 +79,7 @@ impl crate::Configuration {
         for tag_name in source.extension_tags {
             configuration
                 .tag_name_map
-                .insert(tag_name.to_string(), crate::TagClass::ExtensionTag);
+                .insert((*tag_name).to_string(), crate::TagClass::ExtensionTag);
         }
         for tag_name in [
             "abbr",
@@ -144,7 +144,7 @@ impl crate::Configuration {
         {
             configuration
                 .tag_name_map
-                .insert(tag_name.to_string(), crate::TagClass::Tag);
+                .insert((*tag_name).to_string(), crate::TagClass::Tag);
         }
         configuration
     }

--- a/src/external_link.rs
+++ b/src/external_link.rs
@@ -38,7 +38,6 @@ pub fn parse_external_link_start(state: &mut crate::State, configuration: &crate
     {
         Err(_) => {
             state.scan_position = scheme_start_position;
-            return;
         }
         Ok(_) => {
             state.push_open_node(crate::OpenNodeType::ExternalLink, scheme_start_position);

--- a/src/heading.rs
+++ b/src/heading.rs
@@ -4,11 +4,8 @@
 
 pub fn parse_heading_end(state: &mut crate::State) {
     let mut end_position = state.scan_position;
-    loop {
-        match state.get_byte(end_position - 1) {
-            Some(b'\t') | Some(b' ') => end_position -= 1,
-            _ => break,
-        }
+    while let Some(b'\t') | Some(b' ') = state.get_byte(end_position - 1) {
+        end_position -= 1;
     }
     let open_node = state.stack.pop().unwrap();
     if state.get_byte(end_position - 1) != Some(b'=') || end_position < open_node.start + 3 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ use state::{OpenNode, OpenNodeType, State};
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
+    ops::Range,
 };
 use trie::Trie;
 pub use warning::{Warning, WarningMessage};
@@ -534,6 +535,16 @@ pub trait Positioned {
 
     /// The byte position in the wiki text where the element starts.
     fn start(&self) -> usize;
+    
+    /// The range of byte positions in the wiki text where the element starts and ends.
+    fn range(&self) -> Range<usize> {
+        self.start()..self.end()
+    }
+    
+    /// Retrieve the wiki text for the element by byte range.
+    fn get_text_from<'a>(&self, text: &'a str) -> &'a str {
+        &text[self.range()]
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/link.rs
+++ b/src/link.rs
@@ -139,14 +139,14 @@ fn parse_end(
                 end: trail_end_position,
                 ordinal: vec![],
                 start: state.scan_position,
-                target: state.wiki_text[target_start_position..target_end_position].trim_right(),
+                target: state.wiki_text[target_start_position..target_end_position].trim_end(),
             });
         }
         Some(crate::Namespace::File) => {
             state.nodes.push(crate::Node::Image {
                 end: trail_end_position,
                 start: state.scan_position,
-                target: state.wiki_text[target_start_position..target_end_position].trim_right(),
+                target: state.wiki_text[target_start_position..target_end_position].trim_end(),
                 text: vec![],
             });
         }
@@ -177,7 +177,7 @@ fn parse_end(
             state.nodes.push(crate::Node::Link {
                 end: trail_end_position,
                 start: state.scan_position,
-                target: &state.wiki_text[target_start_position..target_end_position].trim_right(),
+                target: &state.wiki_text[target_start_position..target_end_position].trim_end(),
                 text,
             });
         }

--- a/src/positioned.rs
+++ b/src/positioned.rs
@@ -85,9 +85,9 @@ impl<'a> crate::Positioned for crate::Node<'a> {
     }
 }
 
-// This assumes that the Vec is not empty and that the start and end values
-// of the nodes in it are in order.
-impl<'a> crate::Positioned for Vec<crate::Node<'a>> {
+// This assumes that the slice is not empty and that the start and end values
+// of its elements are in order.
+impl<P: crate::Positioned> crate::Positioned for [P] {
     fn end(&self) -> usize {
         if let Some(node) = self.last() {
             node.end()

--- a/src/positioned.rs
+++ b/src/positioned.rs
@@ -84,3 +84,23 @@ impl<'a> crate::Positioned for crate::Node<'a> {
         }
     }
 }
+
+// This assumes that the Vec is not empty and that the start and end values
+// of the nodes in it are in order.
+impl<'a> crate::Positioned for Vec<crate::Node<'a>> {
+    fn end(&self) -> usize {
+        if let Some(node) = self.last() {
+            node.end()
+        } else {
+            0
+        }
+    }
+    
+    fn start(&self) -> usize {
+        if let Some(node) = self.first() {
+            node.start()
+        } else {
+            0
+        }
+    }
+}

--- a/src/table.rs
+++ b/src/table.rs
@@ -600,11 +600,8 @@ pub fn start_table(state: &mut crate::State, position_before_line_break: Option<
     }
     state.flushed_position = state.scan_position;
     let mut position = state.scan_position + 2;
-    loop {
-        match state.get_byte(position) {
-            Some(b'\t') | Some(b' ') => position += 1,
-            _ => break,
-        }
+    while let Some(b'\t') | Some(b' ') = state.get_byte(position) {
+        position += 1;
     }
     state.push_open_node(
         crate::OpenNodeType::Table(crate::state::Table {

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -56,7 +56,7 @@ pub enum WarningMessage {
     /// The end tag does not match the last start tag. Rewinding.
     UnexpectedEndTagRewinding,
 
-    /// An end tag was found with no preceeding start tag.
+    /// An end tag was found with no preceding start tag.
     UnexpectedEndTag,
 
     /// Expected heading of higher level. Correcting start of heading.
@@ -91,7 +91,7 @@ impl WarningMessage {
                 "The end tag does not match the last start tag. Rewinding."
             }
             WarningMessage::UnexpectedEndTag => {
-                "An end tag was found with no preceeding start tag."
+                "An end tag was found with no preceding start tag."
             }
             WarningMessage::UnexpectedHeadingLevelCorrecting => {
                 "Expected heading of higher level. Correcting start of heading."


### PR DESCRIPTION
This adds a `get_text_from` method to `Positioned`, which takes a `&str` and returns a substring containing the wikitext of that `Positioned` element, assuming that the `&str` is actually the source wikitext of the `Positioned` element. It also implements `Positioned` for `[Positioned]` (slice of `Positioned`), so that the method can be called on `Vec<Node>` in the fields of the variants of `Node`. I found these changes helpful when writing [enwikt-dump-rs](https://github.com/Erutuon/enwikt-dump-rs) because a method is more convenient than a free function.

`Positioned::get_text_from` uses another new method `Positioned::range`, which returns the `Range` `self.start()..self.end()`, which seemed natural. In fact, it would make sense for `Node` to have a `range` field instead of separate `start` and `end` fields.

There are some other commits here unrelated to the main point of this pull request. I can try to remove them if necessary, though I think this is my first pull request ever.

----

Currently the implementation of `Positioned` for `[Positioned]` makes me uneasy, because it assumes that `[Positioned]` has its items in order, sorted by the return values of the `Positioned::start` and `Positioned::end` methods. If nothing has gone wrong, this should be true of all the `Vec<Node<'a>>`s in `Node`s returned by `Configuration::parse`, but ideally it would be expressed by using a different type, say `OrderedVec<Node>` or `NodeList`, which would be a breaking change.

Additionally, the `Positioned::start` and `Positioned::end` methods on `[Positioned]` simply return `0` when the slice is empty. This is just a kludge that happens to give the right result for `Positioned::get_text_from Really the return type should be `Option<usize>` and the method should return `None` when the slice is empty. But that would require a basic change to the `Positioned` trait. Or else the `Positioned` trait could be implemented only for a slice type that was guaranteed to be non-empty. The latter would not mesh well with `Node`, which can contain empty slices of `Node`s.

These issues both suggest replacing `Vec<Node<'a>>` inside `Node` with a `Vec`-ish type (let's call it `NodeList` that is declared to have all its `Node`s in order. If `Positioned` were implemented for `NodeList`, it would have to return options for all its methods (`Option<usize>` for `start` and `end`, and `Option<&str>` for `get_text_from`), unless `NodeList` were guaranteed to be non-empty, which it can't logically be. Or perhaps `NodeList` could use a different trait, say `OptionallyPositioned`, with the same methods but `Option`al return values.

These ideas seem bad. Perhaps the best solution would be to for the `NodeList`, in addition to guaranteeing that its subnodes (if present) are in order, to have a `range` field that gives its actual (empty) position when it is empty.